### PR TITLE
Fixed tags and categories generated from forestry.io

### DIFF
--- a/_posts/2020-12-02-top-20-reasons-to-learn-java-now-than-ever.md
+++ b/_posts/2020-12-02-top-20-reasons-to-learn-java-now-than-ever.md
@@ -2,11 +2,8 @@
 title: Top 20 reasons to learn Java now than ever
 author: Bazlur Rahman
 date: 2020-12-02 04:00:00 +0000
-categories:
-- conference
-- video
-tags:
-- java
+categories: [Video, Conference]
+tags: [java, bazlur]
 comments: true
 excerpt_separator: ''
 youtube_id: 8GOZRoEUiaA

--- a/_posts/2020-12-12-frequently-asked-questions.md
+++ b/_posts/2020-12-12-frequently-asked-questions.md
@@ -2,9 +2,9 @@
 title: 'Frequently Asked Questions '
 author: Bazlur Rahman
 date: 2020-12-12 05:00:00 +0000
-categories: []
+categories: [Blogging, FAQ]
 comments: true
-tags: []
+tags: [faq]
 image: /assets/media/faq.png
 
 ---
@@ -38,5 +38,3 @@ Answer:  To be a proficient Java programmer, you may need to have experience wit
 6\. Spring framework ( you might not need Java EE if you learn this framework, it's huge and widely used, however, learning both is preferable)  
 7\. Object Relational Mapping tool eg. Hibernate, Top-Link, iBatis.   
 8\. etc.
-
-Q3: 

--- a/_posts/2020-12-12-jugbd-virtual-conference.md
+++ b/_posts/2020-12-12-jugbd-virtual-conference.md
@@ -2,13 +2,8 @@
 title: JUGBD Virtual Conference 2020
 author: JUGBD
 date: 2019-12-12T00:00:00.000+06:00
-categories:
-- Video
-- Conference
-tags:
-- video
-- conference
-- panel discussion
+categories: [Video, Conference]
+tags: [video, conference, panel discussion]
 comments: true
 excerpt_separator: "<!--more-->"
 youtube_id: ozhbNmcD18g


### PR DESCRIPTION
**Reasons for this update**

- For bash script to generate categories and tags pages perfectly we need to have them like `[A, B]`
- We should have categories and tags in same case in all the post for an existing bug
- Categories usually care capitalize and tags are all lowercase letters
- We can add author name as a tag so all the posts from that author can be found in one place. We will add separate author page in future.
